### PR TITLE
Add quick version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maven Central](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/google/guava/guava-beta-checker/maven-metadata.xml.svg?colorB=007ec6)](https://maven-badges.herokuapp.com/maven-central/com.google.guava/guava-beta-checker)
+
 # Guava Beta Checker
 
 An [Error Prone] plugin that checks for usages of [Guava] APIs that are


### PR DESCRIPTION
Make it easier to find the latest version of beta-checker

Other labeling options:
[![Maven Central](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/google/guava/guava-beta-checker/maven-metadata.xml.svg?colorB=007ec6&label=mavenCentral)](https://maven-badges.herokuapp.com/maven-central/com.google.guava/guava-beta-checker)
[![Maven Central](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/google/guava/guava-beta-checker/maven-metadata.xml.svg?colorB=007ec6&label=latest)](https://maven-badges.herokuapp.com/maven-central/com.google.guava/guava-beta-checker)
